### PR TITLE
Reduce Required Node Version to v12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [18]
+        node_version: [12]
       fail-fast: true
 
     steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Library for _"unpacking"_ and reading files inside rar archives as node Readable streams.
 
-**Note: Requires node version >= 18.0.0**
+**Note: Requires node version >= 12.0.0**
 
 **Note: Decompression is not implemented at the moment**
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "packageManager": "pnpm@7.18.2",
   "engines": {
-    "node": ">=18"
+    "node": ">=12"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
This module no longer requires node@18 since support for commonjs was added.

I tested it with node 12+, any lower and it gives errors.