### PR TITLE
Support Async file.createReadStream()

### DIFF
--- a/src/inner-file-stream.ts
+++ b/src/inner-file-stream.ts
@@ -17,13 +17,13 @@ export class InnerFileStream extends Readable {
   get isStarted() {
     return !!this.stream;
   }
-  next() {
+  async next() {
     const chunk = this.rarFileChunks.shift();
 
     if (!chunk) {
       this.push(null);
     } else {
-      this.stream = chunk.getStream();
+      this.stream = await chunk.getStream();
       this.stream?.on("data", (data) => this.pushData(data));
       this.stream?.on("end", () => this.next());
     }

--- a/src/rar-files-package.ts
+++ b/src/rar-files-package.ts
@@ -17,7 +17,7 @@ const parseHeader = async <T extends IParsers>(
   fileMedia: IFileMedia,
   offset = 0
 ) => {
-  const stream = fileMedia.createReadStream({
+  const stream = await fileMedia.createReadStream({
     start: offset,
     end: offset + Parser.HEADER_SIZE,
   });


### PR DESCRIPTION
This is regarding this comment: https://github.com/doom-fish/rar-stream/issues/26#issuecomment-1976870989

I tested the changes with both async and sync `.createReadStream()` and it seems to work fine.