### PR TITLE
Use Node@16 for Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [12]
+        node_version: [16]
       fail-fast: true
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
 
       - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
So it turns out that there was no PNPM version set for tests and it wanted node@14 (PNPM v6 works with node@12 according to the compatibility chart: https://pnpm.io/installation#compatibility )

Then `vitest` wanted node@16.

Not sure if we should also set the required node version for the module to 16 also, as it works fine with node@12, or if we should only set tests to use node@16

Regardless, this PR will fix the tests