### PR TITLE
Set Minimum Node Version to 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [16]
+        node_version: [12]
       fail-fast: true
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 8
+        uses: pnpm/action-setup@v2
 
       - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [12]
+        node_version: [16]
       fail-fast: true
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
 
       - name: Set node version to ${{ matrix.node_version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node_version: [12]
+        node_version: [18]
       fail-fast: true
 
     steps:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Library for _"unpacking"_ and reading files inside rar archives as node Readable streams.
 
-**Note: Requires node version >= 12.0.0**
+**Note: Requires node version >= 18.0.0**
 
 **Note: Decompression is not implemented at the moment**
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "type": "module",
   "packageManager": "pnpm@7.18.2",
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
This PR is an alternative to: https://github.com/doom-fish/rar-stream/pull/31

It reverts the previous commits to set the minimum node version to 18