### PR TITLE
Support Async file.createReadStream() (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,8 @@ const rarFilesPackage = new RarFilesPackage(localRarFiles);
 async function writeInnerRarFilesToDisk() {
   const innerFiles = await rarFilesPackage.parse();
   for (const innerFile of innerFiles) {
-    innerFile
-      .createReadStream({ start: 0, end: innerFile.length - 1 })
-      .pipe(fs.createWriteStream(innerFile.name));
+    const stream = await innerFile.createReadStream({ start: 0, end: innerFile.length - 1 })
+    stream.pipe(fs.createWriteStream(innerFile.name));
   }
 }
 
@@ -84,10 +83,10 @@ Implements the [`FileMedia`](#filemedia-interface) interface.
 
 #### Methods:
 
-| Method                                         | Description                                                             |
-| ---------------------------------------------- | ----------------------------------------------------------------------- |
-| createReadStream({start: number, end: number}) | Returns a `Readable` stream. The start and end interval is inclusive.   |
-| readToEnd                                      | Returns a Promise with a Buffer containing all the content of the file. |
+| Method                                         | Description                                                                          |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------ |
+| createReadStream({start: number, end: number}) | Returns a Promise with a `Readable` stream. The start and end interval is inclusive. |
+| readToEnd                                      | Returns a Promise with a Buffer containing all the content of the file.              |
 
 #### Properties:
 
@@ -100,7 +99,7 @@ Implements the [`FileMedia`](#filemedia-interface) interface.
 
 ```
 const innerFiles = await rarStreamPackage.parse();
-const innerFileStream = innerFiles[0].createReadStream({ start: 0, end: 30});
+const innerFileStream = await innerFiles[0].createReadStream({ start: 0, end: 30});
 ```
 
 ### _FileMedia Interface_
@@ -112,7 +111,7 @@ Should have the following shape:
 ```javascript
  // FileMedia
  {
-  createReadStream(interval: Interval): Readable,
+  createReadStream(interval: Interval): Promise<Readable>,
   name: string,
   length: number // Length or size of the file in bytes
  }

--- a/src/inner-file-stream.ts
+++ b/src/inner-file-stream.ts
@@ -17,13 +17,13 @@ export class InnerFileStream extends Readable {
   get isStarted() {
     return !!this.stream;
   }
-  next() {
+  async next() {
     const chunk = this.rarFileChunks.shift();
 
     if (!chunk) {
       this.push(null);
     } else {
-      this.stream = chunk.getStream();
+      this.stream = await chunk.getStream();
       this.stream?.on("data", (data) => this.pushData(data));
       this.stream?.on("end", () => this.next());
     }

--- a/src/inner-file.ts
+++ b/src/inner-file.ts
@@ -20,10 +20,9 @@ export class InnerFile implements IFileMedia {
 
     this.name = name;
   }
-  readToEnd() {
-    return streamToBuffer(
-      this.createReadStream({ start: 0, end: this.length - 1 })
-    );
+  async readToEnd() {
+    const stream = await this.createReadStream({ start: 0, end: this.length - 1 });
+    return streamToBuffer(stream);
   }
   getChunksToStream(fileStart: number, fileEnd: number) {
     const { index: startIndex, start: startOffset } =
@@ -58,7 +57,9 @@ export class InnerFile implements IFileMedia {
       throw Error("Illegal start/end offset");
     }
 
-    return new InnerFileStream(this.getChunksToStream(start, end));
+    return Promise.resolve(
+      new InnerFileStream(this.getChunksToStream(start, end))
+    );
   }
   calculateChunkMap(rarFileChunks: RarFileChunk[]) {
     const chunkMap: ChunkMapEntry[] = [];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -5,7 +5,7 @@ import { TerminatorHeaderParser } from "./parsing/terminator-header-parser.js";
 export interface IFileMedia {
   length: number;
   name: string;
-  createReadStream(opts?: IReadInterval): NodeJS.ReadableStream;
+  createReadStream(opts?: IReadInterval): Promise<NodeJS.ReadableStream> | NodeJS.ReadableStream;
 }
 export interface IReadInterval {
   start: number;

--- a/src/local-file-media.ts
+++ b/src/local-file-media.ts
@@ -10,6 +10,8 @@ export class LocalFileMedia implements IFileMedia {
     this.length = statSync(path).size;
   }
   createReadStream(interval: IReadInterval) {
-    return createReadStream(this.path, interval);
+    return Promise.resolve(
+      createReadStream(this.path, interval)
+    );
   }
 }

--- a/src/parsing/__mocks__/mock-file-media.ts
+++ b/src/parsing/__mocks__/mock-file-media.ts
@@ -12,6 +12,8 @@ export class MockFileMedia implements IFileMedia {
   length: number;
   name: string;
   createReadStream(options: IReadInterval) {
-    return new MockFileStream(this.buffer, options);
+    return Promise.resolve(
+      new MockFileStream(this.buffer, options)
+    );
   }
 }

--- a/src/rar-file-bundle.test.ts
+++ b/src/rar-file-bundle.test.ts
@@ -7,7 +7,7 @@ const newFileMedia = (name: string) =>
   ({
     name,
     length: 0,
-    createReadStream: () => new Readable(),
+    createReadStream: () => Promise.resolve(new Readable()),
   } satisfies IFileMedia);
 
 test("RarFileBundle length should be 0 with an empty array as input", () => {

--- a/src/rar-file-chunk.test.ts
+++ b/src/rar-file-chunk.test.ts
@@ -7,7 +7,7 @@ test("RarFileChunk#getStream should return a stream from its FileMedia", async (
   const bufferString = "123456789A";
   const fileMedia = new MockFileMedia(bufferString);
   const rarFileChunk = new RarFileChunk(fileMedia, 0, 5);
-  const stream = rarFileChunk.getStream();
+  const stream = await rarFileChunk.getStream();
   const buffer = await streamToBuffer(stream);
   expect(Buffer.from(bufferString, "hex")).toEqual(buffer);
 });
@@ -16,7 +16,7 @@ test("RarFileChunk#getStream should return a stream with a subset stream of File
   const bufferString = "123456789A";
   const fileMedia = new MockFileMedia(bufferString);
   const rarFileChunk = new RarFileChunk(fileMedia, 2, 5);
-  const stream = rarFileChunk.getStream();
+  const stream = await rarFileChunk.getStream();
   const buffer = await streamToBuffer(stream);
   expect(Buffer.from("56789A", "hex")).toEqual(buffer);
 });
@@ -25,7 +25,7 @@ test("RarFileChunk#getStream should return a stream with another subset stream o
   const bufferString = "123456789A";
   const fileMedia = new MockFileMedia(bufferString);
   const rarFileChunk = new RarFileChunk(fileMedia, 1, 3);
-  const stream = rarFileChunk.getStream();
+  const stream = await rarFileChunk.getStream();
   const buffer = await streamToBuffer(stream);
   expect(Buffer.from("3456", "hex")).toEqual(buffer);
 });

--- a/src/rar-files-package.test.ts
+++ b/src/rar-files-package.test.ts
@@ -114,7 +114,7 @@ test("single rar file with one inner files can be read in parts", async () => {
   const rarPackage = new RarFilesPackage(singleFileRarWithOneInnerFile);
 
   const [file] = await rarPackage.parse();
-  const rarFileInterval = file?.createReadStream(interval);
+  const rarFileInterval = await file?.createReadStream(interval);
   const singleFileInterval = fs.createReadStream(singleFilePath, interval);
   const rarFileBuffer = await streamToBuffer(rarFileInterval!);
   const singleFileBuffer = await streamToBuffer(singleFileInterval);
@@ -150,13 +150,13 @@ test("single rar file with many inner files can be read in parts", async () => {
   const [rarFile1, rarFile2, rarFile3] = await rarPackage.parse();
 
   const rarFile1Buffer = await streamToBuffer(
-    rarFile1!.createReadStream(interval)
+    await rarFile1!.createReadStream(interval)
   );
   const rarFile2Buffer = await streamToBuffer(
-    rarFile2!.createReadStream(interval)
+    await rarFile2!.createReadStream(interval)
   );
   const rarFile3Buffer = await streamToBuffer(
-    rarFile3!.createReadStream(interval)
+    await rarFile3!.createReadStream(interval)
   );
 
   const splittedFile1Buffer = await streamToBuffer(
@@ -192,7 +192,7 @@ test("multiple rar file with one inner can be read as in parts", async () => {
   const rarPackage = new RarFilesPackage(multipleRarFileWithOneInnerFile);
 
   const [file] = await rarPackage.parse();
-  const rarFileBuffer = await streamToBuffer(file!.createReadStream(interval));
+  const rarFileBuffer = await streamToBuffer(await file!.createReadStream(interval));
   const multiFileBuffer = await streamToBuffer(
     fs.createReadStream(multiFilePath, interval)
   );
@@ -225,16 +225,16 @@ test("multi rar file with many inner files can be read in parts", async () => {
   const [rarFile1, rarFile2, rarFile3, rarFile4] = await rarPackage.parse();
 
   const rarFile1Buffer = await streamToBuffer(
-    rarFile1!.createReadStream(interval)
+    await rarFile1!.createReadStream(interval)
   );
   const rarFile2Buffer = await streamToBuffer(
-    rarFile2!.createReadStream(interval)
+    await rarFile2!.createReadStream(interval)
   );
   const rarFile3Buffer = await streamToBuffer(
-    rarFile3!.createReadStream(interval)
+    await rarFile3!.createReadStream(interval)
   );
   const rarFile4Buffer = await streamToBuffer(
-    rarFile4!.createReadStream(interval)
+    await rarFile4!.createReadStream(interval)
   );
 
   const splittedFile1Buffer = await streamToBuffer(

--- a/src/rar-files-package.ts
+++ b/src/rar-files-package.ts
@@ -17,7 +17,7 @@ const parseHeader = async <T extends IParsers>(
   fileMedia: IFileMedia,
   offset = 0
 ) => {
-  const stream = fileMedia.createReadStream({
+  const stream = await fileMedia.createReadStream({
     start: offset,
     end: offset + Parser.HEADER_SIZE,
   });


### PR DESCRIPTION
Alternative PR to: https://github.com/doom-fish/rar-stream/pull/29

This makes all `InnerFile.createReadStream()` async, with support for sync `.createReadStream()` for the `InnerFile` objects that are sent by users in `new RarFilesPackage()`. This is done by using `await` internally, so there is also backward support for sync `.createReadStream()` for `torrent-stream` and `webtorrent`.

**Merging this PR will break backward compatibility** as users would need to either use `await` or `.then().catch()` for the `InnerFile` objects returned by the module, so **it should be released as a new major version**.

All tests are passing, I tested with both async and sync for the `InnerFile` objects sent to `new RarFilesPackage()`, both worked fine.

_Related comment: https://github.com/doom-fish/rar-stream/issues/26#issuecomment-1976870989_