### PR TITLE
build: use postinstall instead of prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "vitest",
     "build": "tsup",
     "coverage": "vitest --coverage",
-    "prepublish": "npm run build"
+    "postinstall": "npm run build"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Use `postinstall` instead of `prepublish`, which is deprecated and doesn't work as expected with `yarn`