### PR TITLE
Support PARTX and PARTXXX

### DIFF
--- a/src/rar-file-bundle.ts
+++ b/src/rar-file-bundle.ts
@@ -1,6 +1,6 @@
 const RXX_EXTENSION = /\.R(\d\d)$|.RAR$/i;
 const RAR_EXTENSION = /.RAR$/i;
-const PARTXX_RAR_EXTENSION = /.PART(\d\d).RAR/i;
+const PARTXX_RAR_EXTENSION = /.PART(\d\d?\d?).RAR/i;
 import { IFileMedia } from "./interfaces.js";
 
 const isPartXXExtension = (fileMedias: IFileMedia[] = []) => {


### PR DESCRIPTION
We noticed that `.part01.rar` can also be `.part1.rar` and `.part.001.rar` in some cases, we have not seen cases of `.part.0001.rar` yet so we didn't add it yet.